### PR TITLE
fix: remove root exception handler to trigger stop

### DIFF
--- a/firecracker/process.py
+++ b/firecracker/process.py
@@ -178,7 +178,10 @@ class ProcessManager:
             id (str): VM ID for logging
 
         Returns:
-            bool: True if process was successfully stopped, False otherwise
+            bool: True if process was successfully stopped
+
+        Raises:
+            ProcessError: If process fails to stop after retries
         """
         try:
             os.kill(pid, 15)  # SIGTERM

--- a/firecracker/process.py
+++ b/firecracker/process.py
@@ -181,7 +181,7 @@ class ProcessManager:
             bool: True if process was successfully stopped
 
         Raises:
-            ProcessError: If process fails to stop after retries
+            ProcessError: If process fails to stop
         """
         try:
             os.kill(pid, 15)  # SIGTERM


### PR DESCRIPTION
In the `_try_stop_process` function having root exception handler, and will not triggering the retry in case of stop process is failed. So, removing it to trigger retry.