### PR TITLE
fix: defunct process when killing the machine

### DIFF
--- a/firecracker/network.py
+++ b/firecracker/network.py
@@ -168,7 +168,7 @@ class NetworkManager:
         """
         if not self.is_nftables_available():
             if self._config.verbose:
-                self._logger.warning("Nftables not available, skipping command")
+                self._logger.warn("Nftables not available, skipping command")
             return None, None, None
             
         try:
@@ -193,7 +193,7 @@ class NetworkManager:
         """
         if not self.is_nftables_available():
             if self._config.verbose:
-                self._logger.warning("Nftables not available, skipping NAT rules")
+                self._logger.warn("Nftables not available, skipping NAT rules")
             return
             
         try:

--- a/firecracker/process.py
+++ b/firecracker/process.py
@@ -117,7 +117,7 @@ class ProcessManager:
 
     @retry(
         stop=stop_after_attempt(5),
-        wait=wait_fixed(0.5),
+        wait=wait_fixed(1),
         retry=retry_if_exception_type((ProcessError, OSError)),
     )
     def stop(self, id: str) -> bool:
@@ -167,6 +167,9 @@ class ProcessManager:
                 self._cleanup_files(id)
                 return True
             else:
+                # Clean up files even if no process found
+                self._cleanup_files(id)
+
                 if self._logger.verbose:
                     self._logger.info("Firecracker is not running (no PID file)")
                 return False

--- a/firecracker/process.py
+++ b/firecracker/process.py
@@ -54,7 +54,7 @@ class ProcessManager:
                 preexec_fn=lambda: os.setpgid(0, parent_pgid),
             )
 
-            time.sleep(0.2)
+            time.sleep(0.5)
 
             if process.poll() is not None:
                 raise ProcessError("Firecracker process exited during startup")
@@ -189,23 +189,12 @@ class ProcessManager:
         Raises:
             ProcessError: If process fails to stop
         """
-        try:
-            os.kill(pid, 15)  # SIGTERM
-            time.sleep(0.5)
-        except OSError as e:
-            if e.errno == 3:  # ESRCH - No such process
-                if self._logger.verbose:
-                    self._logger.info(f"Firecracker process {pid} already terminated")
-                return True
-            else:
-                raise ProcessError(f"Failed to send SIGTERM to process {pid}: {e}")
-
         # Check if process is still running
         try:
             os.kill(pid, 0)  # Check if process exists
             # Process still running, try force kill
             os.kill(pid, 9)  # SIGKILL
-            time.sleep(0.2)
+            time.sleep(1)
 
             # Verify process is actually killed
             try:

--- a/firecracker/process.py
+++ b/firecracker/process.py
@@ -235,7 +235,7 @@ class ProcessManager:
                 return True
             else:
                 if self._logger.verbose:
-                    self._logger.warning(
+                    self._logger.warn(
                         f"Process {pid} did not terminate after SIGTERM, using SIGKILL"
                     )
 
@@ -310,7 +310,7 @@ class ProcessManager:
 
         except Exception as e:
             if self._logger.verbose:
-                self._logger.warning(f"Error searching for running process: {e}")
+                self._logger.warn(f"Error searching for running process: {e}")
 
         return None
 
@@ -329,7 +329,7 @@ class ProcessManager:
                     self._logger.debug(f"Removed PID file for VM {id}")
             except OSError as e:
                 if self._logger.verbose:
-                    self._logger.warning(f"Failed to remove PID file: {e}")
+                    self._logger.warn(f"Failed to remove PID file: {e}")
 
         # Clean up socket file
         socket_path = f"{self._config.data_path}/{id}/firecracker.socket"
@@ -340,7 +340,7 @@ class ProcessManager:
                     self._logger.debug(f"Removed socket file: {socket_path}")
             except OSError as e:
                 if self._logger.verbose:
-                    self._logger.warning(f"Failed to remove socket file: {e}")
+                    self._logger.warn(f"Failed to remove socket file: {e}")
 
     def get_pid(self, id: str) -> tuple:
         """Get the PID of the Firecracker process.

--- a/firecracker/process.py
+++ b/firecracker/process.py
@@ -139,6 +139,7 @@ class ProcessManager:
 
                 # Try to stop using the PID from file
                 if self._try_stop_process(original_pid, id):
+                    self._cleanup_files(id)
                     return True
 
                 # If PID-based stop failed, search for actual running process
@@ -154,6 +155,7 @@ class ProcessManager:
                             f"Found running Firecracker process {actual_pid} for VM {id}"
                         )
                     if self._try_stop_process(actual_pid, id):
+                        self._cleanup_files(id)
                         return True
                 else:
                     if self._logger.verbose:

--- a/firecracker/process.py
+++ b/firecracker/process.py
@@ -51,7 +51,7 @@ class ProcessManager:
                 stderr=subprocess.DEVNULL,
                 stdin=subprocess.DEVNULL,
                 # Explicitly set to parent's group
-                preexec_fn=lambda: os.setpgid(1, parent_pgid),
+                preexec_fn=lambda: os.setpgid(0, parent_pgid),
             )
 
             time.sleep(0.2)

--- a/firecracker/process.py
+++ b/firecracker/process.py
@@ -42,12 +42,16 @@ class ProcessManager:
             log_path = f"{self._config.data_path}/{id}/firecracker.log"
             pid_path = f"{self._config.data_path}/{id}/firecracker.pid"
 
+            # Get parent's process group
+            parent_pgid = os.getpgid(0)
+
             process = subprocess.Popen(
                 cmd,
                 stdout=open(log_path, "w"),
                 stderr=subprocess.DEVNULL,
                 stdin=subprocess.DEVNULL,
-                start_new_session=True,
+                # Explicitly set to parent's group
+                preexec_fn=lambda: os.setpgid(1, parent_pgid),
             )
 
             time.sleep(0.2)

--- a/firecracker/vmm.py
+++ b/firecracker/vmm.py
@@ -143,7 +143,7 @@ class VMMManager:
                     
             except (json.JSONDecodeError, IOError) as e:
                 if self._config.verbose:
-                    self._logger.warning(f"Failed to read config for VMM {vmm_id}: {e}")
+                    self._logger.warn(f"Failed to read config for VMM {vmm_id}: {e}")
                 continue
 
         return vmm_list
@@ -217,7 +217,7 @@ class VMMManager:
                         
                 except (json.JSONDecodeError, IOError) as e:
                     if self._config.verbose:
-                        self._logger.warning(f"Failed to read config for VMM {vmm_id}: {e}")
+                        self._logger.warn(f"Failed to read config for VMM {vmm_id}: {e}")
                     continue
 
             return matching_vmm_ids


### PR DESCRIPTION
- [x] fix: defunct process when killing the machine by changing the PID to parent group
- [x] fix: folder not cleanup properly
- [x] fix: add wait until process got killed
- [x] fix: logger doesn't have warning
- [x] feat: implement finding the running PID of the machine when failed to kill 1st attempt