### PR TITLE
enhance: add filesystem check and cleanup in MicroVM class

### DIFF
--- a/firecracker/microvm.py
+++ b/firecracker/microvm.py
@@ -1366,6 +1366,10 @@ class MicroVM:
             if self._config.verbose:
                 self._logger.debug(f"Formatting filesystem: {file} with size {size}")
 
+            run(f"e2fsck -f -y {file}")
+            if self._config.verbose:
+                self._logger.debug(f"Filesystem check completed for: {file}")
+
             tmp_dir = tempfile.mkdtemp()
             run(f"mount -o loop {file} {tmp_dir}")
 
@@ -1375,6 +1379,11 @@ class MicroVM:
             os.remove(tar_file)
             if self._config.verbose:
                 self._logger.debug(f"Removed tar file: {tar_file}")
+
+            run(f"umount {tmp_dir}")
+            os.rmdir(tmp_dir)
+            if self._config.verbose:
+                self._logger.debug(f"Unmounted and removed temporary directory: {tmp_dir}")
 
             if self._config.verbose:
                 self._logger.info("Build rootfs completed")

--- a/firecracker/network.py
+++ b/firecracker/network.py
@@ -727,9 +727,15 @@ class NetworkManager:
 
         try:
             for rule in rules["nftables"]:
-                rc, output, error = self._nft.json_cmd({"nftables": [rule]})
-                if rc != 0 and "File exists" not in str(error):
-                    raise NetworkError(f"Failed to add port forwarding rule: {error}")
+                rc, _, error = self._nft.json_cmd({"nftables": [rule]})
+                if rc != 0:
+                    error_str = str(error)
+                    ignore_errors = [
+                        "File exists",
+                        "already exists",
+                    ]
+                    if not any(err in error_str for err in ignore_errors):
+                        raise NetworkError(f"Failed to add port forwarding rule: {error}")
 
             if self._config.verbose:
                 self._logger.info(f"Added port forwarding rule: {host_ip}:{host_port} -> {dest_ip}:{dest_port}")


### PR DESCRIPTION
This commit introduces a filesystem check using e2fsck before mounting the root filesystem in the MicroVM class. It also ensures proper unmounting and removal of the temporary directory after use, improving the robustness of the filesystem handling process. Verbose logging has been added to provide feedback on these operations.

This is to prevent dangling vms on failed provisions.